### PR TITLE
ci: build and publish cross-platform wheels

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,48 @@
+name: Build wheels
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install cibuildwheel==2.16.2
+      - name: Build wheels
+        run: cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+          CIBW_ARCHS_LINUX: "x86_64 aarch64"
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_ARCHS_WINDOWS: "AMD64 x86"
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel}"
+      - name: Push wheels to wheel repository
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          WHEEL_REPO: ${{ secrets.WHEEL_REPO }}
+          WHEEL_REPO_TOKEN: ${{ secrets.WHEEL_REPO_TOKEN }}
+        run: |
+          git clone https://${WHEEL_REPO_TOKEN}@github.com/${WHEEL_REPO}.git wheel-repo
+          cp wheelhouse/*.whl wheel-repo/
+          cd wheel-repo
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git add *.whl
+          git commit -m "Add wheels for ${GITHUB_REF##*/}"
+          git push


### PR DESCRIPTION
## Summary
- build wheels for CPython 3.8-3.13 across Linux, Windows, and macOS (x86_64/arm64)
- repair Linux wheels with auditwheel and push artifacts to a separate wheel repository

## Testing
- `pip install -e .`
