### PR TITLE
Add comprehensive documentation for Python API

### DIFF
--- a/docs/TVD_Condat2013.rst
+++ b/docs/TVD_Condat2013.rst
@@ -1,4 +1,0 @@
-TVDCondat2013
-=========================
-
-.. automodule:: TVDCondat2013

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,7 @@
+API Reference
+=============
+
+.. automodule:: TVDCondat2013
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,10 +15,10 @@
 import sys
 import os
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+# Ensure the compiled extension and package root are importable when building
+# the documentation. This allows ``autodoc`` to pull docstrings from the
+# extension module without requiring installation beforehand.
+sys.path.insert(0, os.path.abspath('..'))
 
 # -- General configuration ------------------------------------------------
 
@@ -70,7 +70,7 @@ release = u'0.0.1'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -291,4 +291,6 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,35 @@
 TVDCondat2013 Documentation
 =======================================
 
-Contents:
+TVDCondat2013 provides fast 1-D total variation denoising routines based on
+Laurent Condat's algorithms. The core is written in C++ and exposed to Python
+through pybind11, offering a tiny, dependency-free extension.
+
+Quick start
+-----------
+
+.. code-block:: python
+
+    import numpy as np
+    from TVDCondat2013 import TVD
+
+    noisy = np.random.randn(100)
+    denoised = TVD(noisy, 10.0)
+
+The module also exposes ``TVD_v2`` and ``D_TVD_R`` helpers for alternative
+use-cases. See the :doc:`api` reference for the complete list of functions and
+their arguments.
+
+References
+----------
+
+* L. Condat, "A Direct Algorithm for 1D Total Variation Denoising," *IEEE
+  Signal Processing Letters*, 2013.
+* L. Condat, "Fast Projection onto the Simplex and the L1 Ball," *Mathematical
+  Programming*, 2017.
 
 .. toctree::
    :maxdepth: 1
 
-   TVDCondat2013 
+   api
 


### PR DESCRIPTION
## Summary
- document core TV denoising algorithms with explanatory comments
- add Sphinx docs with quick start, API reference, and references to Condat's work
- configure documentation build for autodoc of pybind module

## Testing
- `pytest -q`
- `python -m sphinx -b html docs docs/_build/html`
