### PR TITLE
Document v2 tools and modernize docs theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 TVDCondat2013
 ==============
 
-*UPDATE 2025* : Still using that code as is, I updated the references and I am now preparing a `pip` package precompiled for Window/Mac/Linux. I'm also updating the method to a more optimised version. 
+*UPDATE 2025* : Still using that code as is, I updated the references and I am now preparing a `pip` package precompiled for Window/Mac/Linux. I'm also updating the method to a more optimised version.
+
+Version 2 of the tools implements Condat's 2017 improvements, providing faster convergence while keeping the same interface.
 
 TVDCondat2013 is a python portage of the 1D Total Variation Denoising algorithm from Condat 2013: _A Direct Algorithm for 1D Total Variation Denoising_ (Sign. Proc. Letters, DOI:10.1109/LSP.2013.2278339) using pybind11 to bind C++ and NumPy directly.
 
@@ -19,25 +21,32 @@ This work
 Quick start
 ------------
 
-So far the following denoising of a `numpy` array are implemented:
-
-**Quick use of the original denoising**
-```
-from TVDCondat2013 import TVD
-...
-denoised = TVD(MyNumpyArray,lambda_TVD)
-...
+So far the following denoising of a `numpy` array are implemented. Both the
+original 2013 algorithm and the faster 2017 variant are exposed:
 
 ```
-
-Run `python examples/example_readme.py` to generate a figure comparing the original, noisy, and TVD-denoised signals. The script builds a piecewise-constant signal, corrupts it with Gaussian noise, denoises it with TVD, and plots the three signals in aligned subplots, saving the result as `examples/Example.png`.
-
-**More experimental: curve denoising. So far the boundary condition might shift up or down the data. I am working on it**
+from TVDCondat2013 import TVD, TVD_v2
+...
+denoised_v1 = TVD(MyNumpyArray, lambda_TVD)       # 2013 algorithm
+denoised_v2 = TVD_v2(MyNumpyArray, lambda_TVD)    # 2017 algorithm
+...
 
 ```
-from TVDCondat2013 import D_TVD_R
+
+Run `python examples/example_readme.py` to generate a figure comparing the
+original, noisy, and denoised signals using both algorithms. The script builds a
+piecewise-constant signal, corrupts it with Gaussian noise, denoises it with
+``TVD`` and ``TVD_v2``, and plots the results in aligned subplots, saving the
+figure as `examples/Example.png`.
+
+**More experimental: curve denoising. So far the boundary condition might shift
+up or down the data. I am working on it**
+
+```
+from TVDCondat2013 import D_TVD_R, D_TVD_R_v2
 ...
-curve_denoised = D_TVD_R((MyNumpyArray_of_curve,lambda_TVD))
+curve_denoised_v1 = D_TVD_R(MyNumpyArray_of_curve, lambda_TVD)
+curve_denoised_v2 = D_TVD_R_v2(MyNumpyArray_of_curve, lambda_TVD)
 ...
 
 ```
@@ -108,6 +117,7 @@ The following command generates HTML-based reference documentation; for other
 formats please refer to the Sphinx manual:
 
  - `TVDCondat2013/docs`
+ - `pip install sphinx furo`
  - `make html`
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,9 +112,10 @@ todo_include_todos = False
 
 # -- Options for HTML output ----------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-html_theme = 'alabaster'
+# The theme to use for HTML pages.  ``furo`` provides a clean, responsive
+# layout without additional configuration and gives the documentation a more
+# modern appearance.
+html_theme = "furo"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,14 @@
 TVDCondat2013 Documentation
 =======================================
 
-TVDCondat2013 provides fast 1-D total variation denoising routines based on
+TVDCondat2013 provides fast 1‑D total variation denoising routines based on
 Laurent Condat's algorithms. The core is written in C++ and exposed to Python
-through pybind11, offering a tiny, dependency-free extension.
+through pybind11, offering a tiny, dependency‑free extension.  Two
+implementations are available:
+
+* ``TVD`` and ``D_TVD_R`` — direct ports of the 2013 algorithm.
+* ``TVD_v2`` and ``D_TVD_R_v2`` — an accelerated variant derived from Condat's
+  2017 work with improved convergence on large signals.
 
 Quick start
 -----------
@@ -11,14 +16,15 @@ Quick start
 .. code-block:: python
 
     import numpy as np
-    from TVDCondat2013 import TVD
+    from TVDCondat2013 import TVD, TVD_v2
 
     noisy = np.random.randn(100)
-    denoised = TVD(noisy, 10.0)
+    denoised = TVD(noisy, 10.0)       # 2013 algorithm
+    denoised_v2 = TVD_v2(noisy, 10.0) # 2017 algorithm
 
-The module also exposes ``TVD_v2`` and ``D_TVD_R`` helpers for alternative
-use-cases. See the :doc:`api` reference for the complete list of functions and
-their arguments.
+``D_TVD_R`` and ``D_TVD_R_v2`` offer the same pair of algorithms for the
+detrend–denoise–retrend workflow.  See the :doc:`api` reference for the complete
+list of functions and their arguments.
 
 References
 ----------

--- a/examples/example_DTVDR.py
+++ b/examples/example_DTVDR.py
@@ -1,7 +1,7 @@
 import matplotlib
 matplotlib.use('Agg')
 import numpy as np
-from TVDCondat2013 import TVD, D_TVD_R
+from TVDCondat2013 import TVD, D_TVD_R, D_TVD_R_v2
 from matplotlib import pyplot as plt
 
 
@@ -38,9 +38,11 @@ lambda_TVD = [100,250,500,5000,10000]
 # Denoising with different lambda
 
 for l in lambda_TVD:
-	print('lambda: ', l)
-	denoised = D_TVD_R(A,l)
-	plt.plot(X,denoised, lw = 1, zorder = 2, label= r"TVD $\lambda$ = %s"%(l))
+        print('lambda: ', l)
+        denoised_v1 = D_TVD_R(A,l)
+        denoised_v2 = D_TVD_R_v2(A,l)
+        plt.plot(X,denoised_v1, lw = 1, zorder = 2, label= r"TVD $\lambda$ = %s"%(l))
+        plt.plot(X,denoised_v2, lw = 1, zorder = 2, linestyle='--', label= r"TVD_v2 $\lambda$ = %s"%(l))
 
 
 

--- a/examples/example_readme.py
+++ b/examples/example_readme.py
@@ -1,7 +1,8 @@
 """Example illustrating 1D denoising with :mod:`TVDCondat2013`.
 
 The script generates a piecewise-constant signal, corrupts it with Gaussian
-noise, denoises it, and saves a figure comparing the three signals.
+noise, denoises it with both available algorithms, and saves a figure comparing
+the results.
 """
 
 import matplotlib
@@ -11,7 +12,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 from pathlib import Path
 
-from TVDCondat2013 import TVD
+from TVDCondat2013 import TVD, TVD_v2
 
 
 def main() -> None:
@@ -27,13 +28,14 @@ def main() -> None:
 
     # Denoise the 1-D signal with a reasonable lambda
     lambda_tvd = 10.0
-    denoised = TVD(noisy, lambda_tvd)
+    denoised_v1 = TVD(noisy, lambda_tvd)
+    denoised_v2 = TVD_v2(noisy, lambda_tvd)
 
     # ------------------------------------------------------------------
     # Plot original, noisy, and denoised signals in separate panels
     # ------------------------------------------------------------------
     x = np.arange(clean.size)
-    fig, axes = plt.subplots(3, 1, sharex=True, figsize=(8, 6))
+    fig, axes = plt.subplots(4, 1, sharex=True, figsize=(8, 8))
 
     axes[0].plot(x, clean, color="k", lw=1)
     axes[0].set_ylabel("Amplitude")
@@ -43,10 +45,14 @@ def main() -> None:
     axes[1].set_ylabel("Amplitude")
     axes[1].set_title("Noisy signal")
 
-    axes[2].plot(x, denoised, color="C1", lw=1.5)
-    axes[2].set_xlabel("Sample")
+    axes[2].plot(x, denoised_v1, color="C1", lw=1.5)
     axes[2].set_ylabel("Amplitude")
-    axes[2].set_title(f"Denoised with TVD (lambda={lambda_tvd})")
+    axes[2].set_title(f"TVD (lambda={lambda_tvd})")
+
+    axes[3].plot(x, denoised_v2, color="C2", lw=1.5)
+    axes[3].set_xlabel("Sample")
+    axes[3].set_ylabel("Amplitude")
+    axes[3].set_title(f"TVD_v2 (lambda={lambda_tvd})")
 
     fig.tight_layout()
     output_path = Path(__file__).with_name("Example.png")


### PR DESCRIPTION
## Summary
- document availability of `TVD_v2` and `D_TVD_R_v2` in README and Sphinx index
- modernize documentation theme by switching to Furo
- update examples to demonstrate both algorithm versions

## Testing
- `pytest`
- `sphinx-build -b html docs docs/_build/html` *(fails: failed to fetch intersphinx inventory)*

------
https://chatgpt.com/codex/tasks/task_e_68b69cc6ead8832896e4361e88157459