### PR TITLE
Add taut string TV denoiser and document copyright

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,23 +21,26 @@ This work
 Quick start
 ------------
 
-So far the following denoising of a `numpy` array are implemented. Both the
-original 2013 algorithm and the faster 2017 variant are exposed:
+So far the following denoising of a `numpy` array are implemented. The
+original 2013 algorithm, the faster 2017 variant, a taut string algorithm, and
+a fused lasso variant with an additional :math:`\ell_1` penalty are exposed:
 
 ```
-from TVDCondat2013 import tvd_2013, tvd_2017
+from TVDCondat2013 import fused_lasso, tvd_2013, tvd_2017, tvd_tautstring
 ...
 denoised_v1 = tvd_2013(MyNumpyArray, lambda_TVD)       # 2013 algorithm
 denoised_v2 = tvd_2017(MyNumpyArray, lambda_TVD)       # 2017 algorithm
+denoised_ts = tvd_tautstring(MyNumpyArray, lambda_TVD) # taut string
+denoised_fl = fused_lasso(MyNumpyArray, lambda_TVD, mu_L1) # fused lasso
 ...
 
 ```
 
 Run `python examples/example_readme.py` to generate a figure comparing the
-original, noisy, and denoised signals using both algorithms. The script builds a
+original, noisy, and denoised signals using all algorithms. The script builds a
 piecewise-constant signal, corrupts it with Gaussian noise, denoises it with
-``tvd_2013`` and ``tvd_2017``, and plots the results in aligned subplots, saving
-the figure as `examples/Example.png`.
+``tvd_2013``, ``tvd_2017``, ``tvd_tautstring`` and ``fused_lasso``, and plots
+the results in aligned subplots, saving the figure as `examples/Example.png`.
 
 More working examples in the `examples` folder.
 
@@ -117,3 +120,9 @@ Running the tests requires `pytest`.
 ```bash
 py.test .
 ```
+
+Copyright
+---------
+
+Portions of this software are Copyright (c) 2013-2025 Laurent Condat.
+The taut string algorithm is adapted from Matlab code by Lutz Dümbgen.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,12 +3,16 @@ TVDCondat2013 Documentation
 
 TVDCondat2013 provides fast 1‑D total variation denoising routines based on
 Laurent Condat's algorithms. The core is written in C++ and exposed to Python
-through pybind11, offering a tiny, dependency‑free extension.  Two
+through pybind11, offering a tiny, dependency‑free extension.  Four
 implementations are available:
 
 * ``tvd_2013`` — direct port of the 2013 algorithm.
 * ``tvd_2017`` — an accelerated variant derived from Condat's 2017 work with
   improved convergence on large signals.
+* ``tvd_tautstring`` — taut string algorithm adapted from Lutz Dümbgen's Matlab
+  code.
+* ``fused_lasso`` — fused lasso signal approximator with an additional
+  :math:`\ell_1` penalty term.
 
 Quick start
 -----------
@@ -16,11 +20,18 @@ Quick start
 .. code-block:: python
 
     import numpy as np
-    from TVDCondat2013 import tvd_2013, tvd_2017
+    from TVDCondat2013 import (
+        fused_lasso,
+        tvd_2013,
+        tvd_2017,
+        tvd_tautstring,
+    )
 
     noisy = np.random.randn(100)
-    denoised = tvd_2013(noisy, 10.0)      # 2013 algorithm
-    denoised_fast = tvd_2017(noisy, 10.0) # 2017 algorithm
+    denoised = tvd_2013(noisy, 10.0)              # 2013 algorithm
+    denoised_fast = tvd_2017(noisy, 10.0)         # 2017 algorithm
+    denoised_ts = tvd_tautstring(noisy, 10.0)     # taut string algorithm
+    denoised_fl = fused_lasso(noisy, 10.0, 1.0)   # fused lasso variant
 
 See the :doc:`api` reference for the complete list of functions and their
 arguments.
@@ -32,6 +43,7 @@ References
   Signal Processing Letters*, 2013.
 * L. Condat, "Fast Projection onto the Simplex and the L1 Ball," *Mathematical
   Programming*, 2017.
+* L. Dümbgen, Matlab code for the taut string algorithm, University of Bern.
 
 .. toctree::
    :maxdepth: 1

--- a/examples/example_readme.py
+++ b/examples/example_readme.py
@@ -1,7 +1,7 @@
 """Example illustrating 1D denoising with :mod:`TVDCondat2013`.
 
 The script generates a piecewise-constant signal, corrupts it with Gaussian
-noise, denoises it with both available algorithms, and saves a figure comparing
+noise, denoises it with all available algorithms, and saves a figure comparing
 the results.
 """
 
@@ -12,7 +12,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 from pathlib import Path
 
-from TVDCondat2013 import tvd_2013, tvd_2017
+from TVDCondat2013 import fused_lasso, tvd_2013, tvd_2017, tvd_tautstring
 
 
 def main() -> None:
@@ -28,14 +28,17 @@ def main() -> None:
 
     # Denoise the 1-D signal with a reasonable lambda
     lambda_tvd = 10.0
+    mu_l1 = 1.0
     denoised_v1 = tvd_2013(noisy, lambda_tvd)
     denoised_v2 = tvd_2017(noisy, lambda_tvd)
+    denoised_ts = tvd_tautstring(noisy, lambda_tvd)
+    denoised_fl = fused_lasso(noisy, lambda_tvd, mu_l1)
 
     # ------------------------------------------------------------------
     # Plot original, noisy, and denoised signals in separate panels
     # ------------------------------------------------------------------
     x = np.arange(clean.size)
-    fig, axes = plt.subplots(4, 1, sharex=True, figsize=(8, 8))
+    fig, axes = plt.subplots(6, 1, sharex=True, figsize=(8, 12))
 
     axes[0].plot(x, clean, color="k", lw=1)
     axes[0].set_ylabel("Amplitude")
@@ -50,9 +53,19 @@ def main() -> None:
     axes[2].set_title(f"tvd_2013 (lambda={lambda_tvd})")
 
     axes[3].plot(x, denoised_v2, color="C2", lw=1.5)
-    axes[3].set_xlabel("Sample")
     axes[3].set_ylabel("Amplitude")
     axes[3].set_title(f"tvd_2017 (lambda={lambda_tvd})")
+
+    axes[4].plot(x, denoised_ts, color="C3", lw=1.5)
+    axes[4].set_ylabel("Amplitude")
+    axes[4].set_title(f"tvd_tautstring (lambda={lambda_tvd})")
+
+    axes[5].plot(x, denoised_fl, color="C4", lw=1.5)
+    axes[5].set_xlabel("Sample")
+    axes[5].set_ylabel("Amplitude")
+    axes[5].set_title(
+        f"fused_lasso (lambda={lambda_tvd}, mu={mu_l1})"
+    )
 
     fig.tight_layout()
     output_path = Path(__file__).with_name("Example.png")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <vector>
+#include <limits>
 
 namespace py = pybind11;
 
@@ -18,32 +19,219 @@ namespace tvd {
 /**
  * @brief Perform 1‑D total variation denoising.
  *
- * This is a direct port of Condat's 2013 algorithm for solving the
- * 1‑D total‑variation denoising problem.  It operates on raw pointers for
- * maximal performance and expects the caller to provide the input and
- * output buffers.  The implementation follows the notation of the
- * original paper and exposes the routine through pybind11.
+ * Direct implementation of Laurent Condat's 2013 algorithm.  The body is kept
+ * as close as possible to the original C reference code; only minimal changes
+ * were made to operate on generic floating point types and integrate with the
+ * Python wrapper.
+ *
+ * @tparam T    Floating point type (float or double).
+ * @param input Noisy input signal.
+ * @param output Buffer receiving the denoised signal.  ``input`` and ``output``
+ *               may point to the same memory for in‑place operation.
+ * @param width Number of samples in the signal.
+ * @param lambda Regularisation parameter (non‑negative).
+ */
+template <typename T>
+void tv1d_denoise(const T *input, T *output, int width, T lambda)
+{
+    if (width > 0)
+    {
+        int k = 0, k0 = 0;                    // current index and segment start
+        T umin = lambda, umax = -lambda;       // dual variables
+        T vmin = input[0] - lambda, vmax = input[0] + lambda; // segment bounds
+        int kplus = 0, kminus = 0;             // last positions of constraints
+        const T twolambda = static_cast<T>(2) * lambda;
+        const T minlambda = -lambda;
+        for (;;)                                   // iterative process
+        {
+            while (k == width - 1)                 // apply boundary condition
+            {
+                if (umin < static_cast<T>(0))
+                {
+                    do
+                        output[k0++] = vmin;
+                    while (k0 <= kminus);
+                    umax = (vmin = input[kminus = k = k0]) + (umin = lambda) - vmax;
+                }
+                else if (umax > static_cast<T>(0))
+                {
+                    do
+                        output[k0++] = vmax;
+                    while (k0 <= kplus);
+                    umin = (vmax = input[kplus = k = k0]) + (umax = minlambda) - vmin;
+                }
+                else
+                {
+                    vmin += umin / (k - k0 + 1);
+                    do
+                        output[k0++] = vmin;
+                    while (k0 <= k);
+                    return;
+                }
+            }
+            if ((umin += input[k + 1] - vmin) < minlambda) // negative jump
+            {
+                do
+                    output[k0++] = vmin;
+                while (k0 <= kminus);
+                vmax = (vmin = input[kplus = kminus = k = k0]) + twolambda;
+                umin = lambda;
+                umax = minlambda;
+            }
+            else if ((umax += input[k + 1] - vmax) > lambda) // positive jump
+            {
+                do
+                    output[k0++] = vmax;
+                while (k0 <= kplus);
+                vmin = (vmax = input[kplus = kminus = k = k0]) - twolambda;
+                umin = lambda;
+                umax = minlambda;
+            }
+            else                                  // no jump, continue
+            {
+                k++;
+                if (umin >= lambda)
+                {
+                    vmin += (umin - lambda) / ((kminus = k) - k0 + 1);
+                    umin = lambda;
+                }
+                if (umax <= minlambda)
+                {
+                    vmax += (umax + lambda) / ((kplus = k) - k0 + 1);
+                    umax = minlambda;
+                }
+            }
+        }
+    }
+}
+
+/**
+ * @brief Fused Lasso Signal Approximator.
+ *
+ * Extension of the above routine including an additional ``mu`` parameter.
+ * The implementation mirrors the reference C code closely and supports
+ * in‑place operation.
+ */
+template <typename T>
+void fused_lasso(const T *input, T *output, int width, T lambda, T mu)
+{
+    if (width > 0)
+    {
+        int k = 0, k0 = 0;
+        T umin = lambda, umax = -lambda;
+        T vmin = input[0] - lambda, vmax = input[0] + lambda;
+        int kplus = 0, kminus = 0;
+        const T twolambda = static_cast<T>(2) * lambda;
+        const T minlambda = -lambda;
+        for (;;)
+        {
+            while (k == width - 1)
+            {
+                if (umin < static_cast<T>(0))
+                {
+                    vmin = vmin > mu ? vmin - mu
+                                      : vmin < -mu ? vmin + mu : static_cast<T>(0);
+                    do
+                        output[k0++] = vmin;
+                    while (k0 <= kminus);
+                    umax = (vmin = input[kminus = k = k0]) + (umin = lambda) - vmax;
+                }
+                else if (umax > static_cast<T>(0))
+                {
+                    vmax = vmax > mu ? vmax - mu
+                                      : vmax < -mu ? vmax + mu : static_cast<T>(0);
+                    do
+                        output[k0++] = vmax;
+                    while (k0 <= kplus);
+                    umin = (vmax = input[kplus = k = k0]) + (umax = minlambda) - vmin;
+                }
+                else
+                {
+                    vmin += umin / (k - k0 + 1);
+                    vmin = vmin > mu ? vmin - mu
+                                     : vmin < -mu ? vmin + mu : static_cast<T>(0);
+                    do
+                        output[k0++] = vmin;
+                    while (k0 <= k);
+                    return;
+                }
+            }
+            if ((umin += input[k + 1] - vmin) < minlambda)
+            {
+                vmin = vmin > mu ? vmin - mu
+                                  : vmin < -mu ? vmin + mu : static_cast<T>(0);
+                do
+                    output[k0++] = vmin;
+                while (k0 <= kminus);
+                vmax = (vmin = input[kplus = kminus = k = k0]) + twolambda;
+                umin = lambda;
+                umax = minlambda;
+            }
+            else if ((umax += input[k + 1] - vmax) > lambda)
+            {
+                vmax = vmax > mu ? vmax - mu
+                                  : vmax < -mu ? vmax + mu : static_cast<T>(0);
+                do
+                    output[k0++] = vmax;
+                while (k0 <= kplus);
+                vmin = (vmax = input[kplus = kminus = k = k0]) - twolambda;
+                umin = lambda;
+                umax = minlambda;
+            }
+            else
+            {
+                k++;
+                if (umin >= lambda)
+                {
+                    vmin += (umin - lambda) / ((kminus = k) - k0 + 1);
+                    umin = lambda;
+                }
+                if (umax <= minlambda)
+                {
+                    vmax += (umax + lambda) / ((kplus = k) - k0 + 1);
+                    umax = minlambda;
+                }
+            }
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// 2017 algorithm (version 2) by Laurent Condat under the CeCILL licence.
+// -----------------------------------------------------------------------------
+
+/**
+ * @brief 1‑D total variation denoising (Condat 2017).
+ *
+ * Implementation of the revised algorithm published in 2017, which is a
+ * simplified and slightly faster variant of the original 2013 routine.
+ * The code is a C++ port of Laurent Condat's reference implementation and
+ * carries the same CeCILL licence (GPL compatible).
  *
  * @tparam T        Floating point type (float or double).
  * @param input     Pointer to the noisy input signal.
- * @param output    Pointer to a pre‑allocated buffer where the denoised
- *                  signal will be written.
+ * @param output    Pointer to a pre‑allocated buffer that will receive the
+ *                  denoised signal.
  * @param width     Number of samples in the signal.
  * @param lambda    Regularisation parameter controlling the amount of
- *                  smoothing.  Larger values yield flatter signals.
+ *                  smoothing.
  */
-template <typename T>
-void tv1d_denoise(const T *input, T *output, unsigned int width, T lambda)
+// The reference implementation operates in double precision.  We keep an
+// internal double routine and expose a templated wrapper that casts inputs and
+// outputs appropriately so that float arrays still benefit from the increased
+// numerical robustness.
+static void tv1d_denoise_v2_double(const double *input, double *output,
+                                   unsigned int width, double lambda)
 {
     std::vector<unsigned int> indstart_low(width);
     std::vector<unsigned int> indstart_up(width);
 
     unsigned int j_low = 0, j_up = 0, jseg = 0, indjseg = 0, i = 1, indjseg2, ind;
-    T output_low_first = input[0] - lambda;
-    T output_low_curr = output_low_first;
-    T output_up_first = input[0] + lambda;
-    T output_up_curr = output_up_first;
-    T twolambda = static_cast<T>(2) * lambda;
+    double output_low_first = input[0] - lambda;
+    double output_low_curr = output_low_first;
+    double output_up_first = input[0] + lambda;
+    double output_up_curr = output_up_first;
+    const double twolambda = 2.0 * lambda;
 
     if (width == 1)
     {
@@ -54,7 +242,7 @@ void tv1d_denoise(const T *input, T *output, unsigned int width, T lambda)
     indstart_low[0] = 0;
     indstart_up[0] = 0;
     width--;
-    for (; i < width; ++i)
+    for (; i < width; i++)
     {
         if (input[i] >= output_low_curr)
         {
@@ -65,20 +253,17 @@ void tv1d_denoise(const T *input, T *output, unsigned int width, T lambda)
                 output[indjseg] = output_up_first;
                 while ((j_up > jseg) &&
                        (output_up_curr <= output[ind = indstart_up[j_up - 1]]))
-                    output_up_curr +=
-                        (output[ind] - output_up_curr) *
-                        static_cast<T>(indstart_up[j_up--] - ind) /
-                        (i - ind + 1);
+                    output_up_curr += (output[ind] - output_up_curr) *
+                                      (double)(indstart_up[j_up--] - ind) /
+                                      (i - ind + 1);
                 if (j_up == jseg)
                 {
-                    while ((output_up_curr <= output_low_first) &&
-                           (jseg < j_low))
+                    while ((output_up_curr <= output_low_first) && (jseg < j_low))
                     {
                         indjseg2 = indstart_low[++jseg];
-                        output_up_curr +=
-                            (output_up_curr - output_low_first) *
-                            static_cast<T>(indjseg2 - indjseg) /
-                            (i - indjseg2 + 1);
+                        output_up_curr += (output_up_curr - output_low_first) *
+                                          (double)(indjseg2 - indjseg) /
+                                          (i - indjseg2 + 1);
                         while (indjseg < indjseg2)
                             output[indjseg++] = output_low_first;
                         output_low_first = output[indjseg];
@@ -87,9 +272,7 @@ void tv1d_denoise(const T *input, T *output, unsigned int width, T lambda)
                     indstart_up[j_up = jseg] = indjseg;
                 }
                 else
-                {
                     output[indstart_up[j_up]] = output_up_curr;
-                }
             }
             else
             {
@@ -99,22 +282,18 @@ void tv1d_denoise(const T *input, T *output, unsigned int width, T lambda)
                     (i - indstart_low[j_low] + 1);
                 output[indjseg] = output_low_first;
                 while ((j_low > jseg) &&
-                       (output_low_curr >=
-                        output[ind = indstart_low[j_low - 1]]))
-                    output_low_curr +=
-                        (output[ind] - output_low_curr) *
-                        static_cast<T>(indstart_low[j_low--] - ind) /
-                        (i - ind + 1);
+                       (output_low_curr >= output[ind = indstart_low[j_low - 1]]))
+                    output_low_curr += (output[ind] - output_low_curr) *
+                                       (double)(indstart_low[j_low--] - ind) /
+                                       (i - ind + 1);
                 if (j_low == jseg)
                 {
-                    while ((output_low_curr >= output_up_first) &&
-                           (jseg < j_up))
+                    while ((output_low_curr >= output_up_first) && (jseg < j_up))
                     {
                         indjseg2 = indstart_up[++jseg];
-                        output_low_curr +=
-                            (output_low_curr - output_up_first) *
-                            static_cast<T>(indjseg2 - indjseg) /
-                            (i - indjseg2 + 1);
+                        output_low_curr += (output_low_curr - output_up_first) *
+                                          (double)(indjseg2 - indjseg) /
+                                          (i - indjseg2 + 1);
                         while (indjseg < indjseg2)
                             output[indjseg++] = output_up_first;
                         output_up_first = output[indjseg];
@@ -125,35 +304,29 @@ void tv1d_denoise(const T *input, T *output, unsigned int width, T lambda)
                         output_low_first = output_low_curr;
                 }
                 else
-                {
                     output[indstart_low[j_low]] = output_low_curr;
-                }
             }
         }
         else
         {
-            output_up_curr +=
-                ((output_low_curr = output[i] =
-                      input[indstart_low[++j_low] = i]) -
-                 output_up_curr) /
-                (i - indstart_up[j_up] + 1);
+            output_up_curr += ((output_low_curr = output[i] =
+                                    input[indstart_low[++j_low] = i]) -
+                                output_up_curr) /
+                               (i - indstart_up[j_up] + 1);
             output[indjseg] = output_up_first;
             while ((j_up > jseg) &&
                    (output_up_curr <= output[ind = indstart_up[j_up - 1]]))
-                output_up_curr +=
-                    (output[ind] - output_up_curr) *
-                    static_cast<T>(indstart_up[j_up--] - ind) /
-                    (i - ind + 1);
+                output_up_curr += (output[ind] - output_up_curr) *
+                                  (double)(indstart_up[j_up--] - ind) /
+                                  (i - ind + 1);
             if (j_up == jseg)
             {
-                while ((output_up_curr <= output_low_first) &&
-                       (jseg < j_low))
+                while ((output_up_curr <= output_low_first) && (jseg < j_low))
                 {
                     indjseg2 = indstart_low[++jseg];
-                    output_up_curr +=
-                        (output_up_curr - output_low_first) *
-                        static_cast<T>(indjseg2 - indjseg) /
-                        (i - indjseg2 + 1);
+                    output_up_curr += (output_up_curr - output_low_first) *
+                                      (double)(indjseg2 - indjseg) /
+                                      (i - indjseg2 + 1);
                     while (indjseg < indjseg2)
                         output[indjseg++] = output_low_first;
                     output_low_first = output[indjseg];
@@ -164,9 +337,7 @@ void tv1d_denoise(const T *input, T *output, unsigned int width, T lambda)
                     output_up_first = output_up_curr;
             }
             else
-            {
                 output[indstart_up[j_up]] = output_up_curr;
-            }
         }
     }
 
@@ -203,29 +374,24 @@ void tv1d_denoise(const T *input, T *output, unsigned int width, T lambda)
         output[indjseg] = output_low_first;
         while ((j_low > jseg) &&
                (output_low_curr >= output[ind = indstart_low[j_low - 1]]))
-            output_low_curr +=
-                (output[ind] - output_low_curr) *
-                static_cast<T>(indstart_low[j_low--] - ind) /
-                (i - ind + 1);
+            output_low_curr += (output[ind] - output_low_curr) *
+                               (double)(indstart_low[j_low--] - ind) /
+                               (i - ind + 1);
         if (j_low == jseg)
         {
             if (output_up_first >= output_low_curr)
-            {
                 while (indjseg <= i)
                     output[indjseg++] = output_low_curr;
-            }
             else
             {
                 output_up_curr += (input[i] - lambda - output_up_curr) /
                                    (i - indstart_up[j_up] + 1);
                 output[indjseg] = output_up_first;
                 while ((j_up > jseg) &&
-                       (output_up_curr <=
-                        output[ind = indstart_up[j_up - 1]]))
-                    output_up_curr +=
-                        (output[ind] - output_up_curr) *
-                        static_cast<T>(indstart_up[j_up--] - ind) /
-                        (i - ind + 1);
+                       (output_up_curr <= output[ind = indstart_up[j_up - 1]]))
+                    output_up_curr += (output[ind] - output_up_curr) *
+                                       (double)(indstart_up[j_up--] - ind) /
+                                       (i - ind + 1);
                 while (jseg < j_up)
                 {
                     indjseg2 = indstart_up[++jseg];
@@ -254,245 +420,110 @@ void tv1d_denoise(const T *input, T *output, unsigned int width, T lambda)
     }
 }
 
-// -----------------------------------------------------------------------------
-// 2017 algorithm (version 2) by Laurent Condat under the CeCILL licence.
-// -----------------------------------------------------------------------------
-
-/**
- * @brief 1‑D total variation denoising (Condat 2017).
- *
- * Implementation of the revised algorithm published in 2017, which is a
- * simplified and slightly faster variant of the original 2013 routine.
- * The code is a C++ port of Laurent Condat's reference implementation and
- * carries the same CeCILL licence (GPL compatible).
- *
- * @tparam T        Floating point type (float or double).
- * @param input     Pointer to the noisy input signal.
- * @param output    Pointer to a pre‑allocated buffer that will receive the
- *                  denoised signal.
- * @param width     Number of samples in the signal.
- * @param lambda    Regularisation parameter controlling the amount of
- *                  smoothing.
- */
 template <typename T>
 void tv1d_denoise_v2(const T *input, T *output, unsigned int width, T lambda)
 {
-    std::vector<unsigned int> indstart_low(width);
-    std::vector<unsigned int> indstart_up(width);
+    // Run the core algorithm in double precision for robustness and cast back
+    // to the original dtype once finished.
+    std::vector<double> in(width), out(width);
+    for (unsigned int k = 0; k < width; ++k)
+        in[k] = static_cast<double>(input[k]);
+    tv1d_denoise_v2_double(in.data(), out.data(), width,
+                           static_cast<double>(lambda));
+    for (unsigned int k = 0; k < width; ++k)
+        output[k] = static_cast<T>(out[k]);
+}
 
-    unsigned int j_low = 0, j_up = 0, jseg = 0, indjseg = 0, i = 1, indjseg2, ind;
-    T output_low_first = input[0] - lambda;
-    T output_low_curr = output_low_first;
-    T output_up_first = input[0] + lambda;
-    T output_up_curr = output_up_first;
-    T twolambda = static_cast<T>(2) * lambda;
-
-    if (width == 1)
-    {
-        output[0] = input[0];
+/**
+ * @brief 1‑D total variation denoising using the taut string algorithm.
+ *
+ * Adapted from the Matlab implementation by Lutz Dümbgen.
+ * Uses double precision internally for numerical stability.
+ */
+template <typename T>
+void tv1d_denoise_tautstring(const T *input, T *output, int width, T lambda)
+{
+    if (width <= 0)
         return;
-    }
+    using FT = double;
+    int N = width + 1;
+    std::vector<int> index_low(N), index_up(N), index(N);
+    std::vector<FT> slope_low(N), slope_up(N), z(N), y_low(N), y_up(N);
 
-    indstart_low[0] = 0;
-    indstart_up[0] = 0;
-    width--;
-    for (; i < width; ++i)
+    int s_low = 0, c_low = 0, s_up = 0, c_up = 0, c = 0;
+    int i = 2;
+
+    y_low[0] = y_up[0] = 0;
+    y_low[1] = static_cast<FT>(input[0]) - static_cast<FT>(lambda);
+    y_up[1] = static_cast<FT>(input[0]) + static_cast<FT>(lambda);
+    for (; i < N; ++i)
     {
-        if (input[i] >= output_low_curr)
+        y_low[i] = y_low[i - 1] + static_cast<FT>(input[i - 1]);
+        y_up[i] = y_up[i - 1] + static_cast<FT>(input[i - 1]);
+    }
+    y_low[N - 1] += static_cast<FT>(lambda);
+    y_up[N - 1] -= static_cast<FT>(lambda);
+
+    slope_low[0] = std::numeric_limits<FT>::infinity();
+    slope_up[0] = -std::numeric_limits<FT>::infinity();
+    z[0] = y_low[0];
+
+    for (i = 1; i < N; ++i)
+    {
+        index_low[++c_low] = index_up[++c_up] = i;
+        slope_low[c_low] = y_low[i] - y_low[i - 1];
+        while ((c_low > s_low + 1) &&
+               (slope_low[std::max(s_low, c_low - 1)] <= slope_low[c_low]))
         {
-            if (input[i] <= output_up_curr)
-            {
-                output_up_curr +=
-                    (input[i] - output_up_curr) / (i - indstart_up[j_up] + 1);
-                output[indjseg] = output_up_first;
-                while ((j_up > jseg) &&
-                       (output_up_curr <= output[ind = indstart_up[j_up - 1]]))
-                    output_up_curr +=
-                        (output[ind] - output_up_curr) *
-                        static_cast<T>(indstart_up[j_up--] - ind) /
-                        (i - ind + 1);
-                if (j_up == jseg)
-                {
-                    while ((output_up_curr <= output_low_first) &&
-                           (jseg < j_low))
-                    {
-                        indjseg2 = indstart_low[++jseg];
-                        output_up_curr +=
-                            (output_up_curr - output_low_first) *
-                            static_cast<T>(indjseg2 - indjseg) /
-                            (i - indjseg2 + 1);
-                        while (indjseg < indjseg2)
-                            output[indjseg++] = output_low_first;
-                        output_low_first = output[indjseg];
-                    }
-                    output_up_first = output_up_curr;
-                    indstart_up[j_up = jseg] = indjseg;
-                }
-                else
-                {
-                    output[indstart_up[j_up]] = output_up_curr;
-                }
-            }
+            index_low[--c_low] = i;
+            if (c_low > s_low + 1)
+                slope_low[c_low] = (y_low[i] - y_low[index_low[c_low - 1]]) /
+                                    (i - index_low[c_low - 1]);
             else
-            {
-                output_up_curr = output[i] = input[indstart_up[++j_up] = i];
-                output_low_curr +=
-                    (input[i] - output_low_curr) /
-                    (i - indstart_low[j_low] + 1);
-                output[indjseg] = output_low_first;
-                while ((j_low > jseg) &&
-                       (output_low_curr >=
-                        output[ind = indstart_low[j_low - 1]]))
-                    output_low_curr +=
-                        (output[ind] - output_low_curr) *
-                        static_cast<T>(indstart_low[j_low--] - ind) /
-                        (i - ind + 1);
-                if (j_low == jseg)
-                {
-                    while ((output_low_curr >= output_up_first) &&
-                           (jseg < j_up))
-                    {
-                        indjseg2 = indstart_up[++jseg];
-                        output_low_curr +=
-                            (output_low_curr - output_up_first) *
-                            static_cast<T>(indjseg2 - indjseg) /
-                            (i - indjseg2 + 1);
-                        while (indjseg < indjseg2)
-                            output[indjseg++] = output_up_first;
-                        output_up_first = output[indjseg];
-                    }
-                    if ((indstart_low[j_low = jseg] = indjseg) == i)
-                        output_low_first = output_up_first - twolambda;
-                    else
-                        output_low_first = output_low_curr;
-                }
-                else
-                {
-                    output[indstart_low[j_low]] = output_low_curr;
-                }
-            }
+                slope_low[c_low] = (y_low[i] - z[c]) / (i - index[c]);
         }
-        else
+
+        slope_up[c_up] = y_up[i] - y_up[i - 1];
+        while ((c_up > s_up + 1) &&
+               (slope_up[std::max(c_up - 1, s_up)] >= slope_up[c_up]))
         {
-            output_up_curr +=
-                ((output_low_curr = output[i] =
-                      input[indstart_low[++j_low] = i]) -
-                 output_up_curr) /
-                (i - indstart_up[j_up] + 1);
-            output[indjseg] = output_up_first;
-            while ((j_up > jseg) &&
-                   (output_up_curr <= output[ind = indstart_up[j_up - 1]]))
-                output_up_curr +=
-                    (output[ind] - output_up_curr) *
-                    static_cast<T>(indstart_up[j_up--] - ind) /
-                    (i - ind + 1);
-            if (j_up == jseg)
-            {
-                while ((output_up_curr <= output_low_first) &&
-                       (jseg < j_low))
-                {
-                    indjseg2 = indstart_low[++jseg];
-                    output_up_curr +=
-                        (output_up_curr - output_low_first) *
-                        static_cast<T>(indjseg2 - indjseg) /
-                        (i - indjseg2 + 1);
-                    while (indjseg < indjseg2)
-                        output[indjseg++] = output_low_first;
-                    output_low_first = output[indjseg];
-                }
-                if ((indstart_up[j_up = jseg] = indjseg) == i)
-                    output_up_first = output_low_first + twolambda;
-                else
-                    output_up_first = output_up_curr;
-            }
+            index_up[--c_up] = i;
+            if (c_up > s_up + 1)
+                slope_up[c_up] = (y_up[i] - y_up[index_up[c_up - 1]]) /
+                                  (i - index_up[c_up - 1]);
             else
-            {
-                output[indstart_up[j_up]] = output_up_curr;
-            }
+                slope_up[c_up] = (y_up[i] - z[c]) / (i - index[c]);
+        }
+
+        while ((c_low == s_low + 1) && (c_up > s_up + 1) &&
+               (slope_low[c_low] >= slope_up[s_up + 1]))
+        {
+            index[++c] = index_up[++s_up];
+            z[c] = y_up[index[c]];
+            index_low[s_low] = index[c];
+            slope_low[c_low] = (y_low[i] - z[c]) / (i - index[c]);
+        }
+        while ((c_up == s_up + 1) && (c_low > s_low + 1) &&
+               (slope_up[c_up] <= slope_low[s_low + 1]))
+        {
+            index[++c] = index_low[++s_low];
+            z[c] = y_low[index[c]];
+            index_up[s_up] = index[c];
+            slope_up[c_up] = (y_up[i] - z[c]) / (i - index[c]);
         }
     }
 
-    if (input[i] + lambda <= output_low_curr)
+    for (i = 1; i <= c_low - s_low; ++i)
+        z[c + i] = y_low[index[c + i] = index_low[s_low + i]];
+    c += c_low - s_low;
+
+    int j = 0;
+    T a;
+    for (i = 1; i <= c; ++i)
     {
-        while (jseg < j_low)
-        {
-            indjseg2 = indstart_low[++jseg];
-            while (indjseg < indjseg2)
-                output[indjseg++] = output_low_first;
-            output_low_first = output[indjseg];
-        }
-        while (indjseg < i)
-            output[indjseg++] = output_low_first;
-        output[indjseg] = input[i] + lambda;
-    }
-    else if (input[i] - lambda >= output_up_curr)
-    {
-        while (jseg < j_up)
-        {
-            indjseg2 = indstart_up[++jseg];
-            while (indjseg < indjseg2)
-                output[indjseg++] = output_up_first;
-            output_up_first = output[indjseg];
-        }
-        while (indjseg < i)
-            output[indjseg++] = output_up_first;
-        output[indjseg] = input[i] - lambda;
-    }
-    else
-    {
-        output_low_curr += (input[i] + lambda - output_low_curr) /
-                           (i - indstart_low[j_low] + 1);
-        output[indjseg] = output_low_first;
-        while ((j_low > jseg) &&
-               (output_low_curr >= output[ind = indstart_low[j_low - 1]]))
-            output_low_curr +=
-                (output[ind] - output_low_curr) *
-                static_cast<T>(indstart_low[j_low--] - ind) /
-                (i - ind + 1);
-        if (j_low == jseg)
-        {
-            if (output_up_first >= output_low_curr)
-            {
-                while (indjseg <= i)
-                    output[indjseg++] = output_low_curr;
-            }
-            else
-            {
-                output_up_curr += (input[i] - lambda - output_up_curr) /
-                                   (i - indstart_up[j_up] + 1);
-                output[indjseg] = output_up_first;
-                while ((j_up > jseg) &&
-                       (output_up_curr <=
-                        output[ind = indstart_up[j_up - 1]]))
-                    output_up_curr +=
-                        (output[ind] - output_up_curr) *
-                        static_cast<T>(indstart_up[j_up--] - ind) /
-                        (i - ind + 1);
-                while (jseg < j_up)
-                {
-                    indjseg2 = indstart_up[++jseg];
-                    while (indjseg < indjseg2)
-                        output[indjseg++] = output_up_first;
-                    output_up_first = output[indjseg];
-                }
-                indjseg = indstart_up[j_up];
-                while (indjseg <= i)
-                    output[indjseg++] = output_up_curr;
-            }
-        }
-        else
-        {
-            while (jseg < j_low)
-            {
-                indjseg2 = indstart_low[++jseg];
-                while (indjseg < indjseg2)
-                    output[indjseg++] = output_low_first;
-                output_low_first = output[indjseg];
-            }
-            indjseg = indstart_low[j_low];
-            while (indjseg <= i)
-                output[indjseg++] = output_low_curr;
-        }
+        a = static_cast<T>((z[i] - z[i - 1]) / (index[i] - index[i - 1]));
+        while (j < index[i])
+            output[j++] = a;
     }
 }
 
@@ -518,7 +549,7 @@ py::array_t<T> tvd_2013(py::array_t<T, py::array::c_style | py::array::forcecast
                         double lambda)
 {
     auto buf = in.request();
-    auto n = static_cast<unsigned int>(buf.size);
+    auto n = static_cast<int>(buf.size);
     const T *data = static_cast<T *>(buf.ptr);
     py::array_t<T> result(buf.size);
     tv1d_denoise(data, result.mutable_data(), n, static_cast<T>(lambda));
@@ -544,6 +575,39 @@ py::array_t<T> tvd_2017(py::array_t<T, py::array::c_style | py::array::forcecast
     return result;
 }
 
+/**
+ * @brief Wrapper for the taut string denoising algorithm.
+ */
+template <typename T>
+py::array_t<T> tvd_tautstring(
+    py::array_t<T, py::array::c_style | py::array::forcecast> in, double lambda)
+{
+    auto buf = in.request();
+    auto n = static_cast<int>(buf.size);
+    const T *data = static_cast<T *>(buf.ptr);
+    py::array_t<T> result(buf.size);
+    tv1d_denoise_tautstring(data, result.mutable_data(), n,
+                            static_cast<T>(lambda));
+    return result;
+}
+
+/**
+ * @brief Wrapper for the fused lasso signal approximator.
+ */
+template <typename T>
+py::array_t<T> fused_lasso_py(
+    py::array_t<T, py::array::c_style | py::array::forcecast> in, double lambda,
+    double mu)
+{
+    auto buf = in.request();
+    auto n = static_cast<int>(buf.size);
+    const T *data = static_cast<T *>(buf.ptr);
+    py::array_t<T> result(buf.size);
+    fused_lasso(data, result.mutable_data(), n, static_cast<T>(lambda),
+                static_cast<T>(mu));
+    return result;
+}
+
 } // namespace tvd
 PYBIND11_MODULE(TVDCondat2013, m)
 {
@@ -551,11 +615,14 @@ PYBIND11_MODULE(TVDCondat2013, m)
     m.doc() = R"pbdoc(
         Python bindings for 1-D total variation denoising based on
         Laurent Condat's algorithms\ [Condat2013]_\ [Condat2017]_.
+        Includes a taut string variant adapted from Lutz Dümbgen's Matlab code.
 
         .. [Condat2013] L. Condat, "A Direct Algorithm for 1D Total Variation
            Denoising," *IEEE Signal Processing Letters*, 2013.
         .. [Condat2017] L. Condat, "Fast Projection onto the Simplex and the
            L1 Ball," *Mathematical Programming*, 2017.
+
+        Copyright (c) 2013-2025 Laurent Condat and contributors.
     )pbdoc";
 
     const char *tvd_doc = R"pbdoc(
@@ -566,6 +633,8 @@ PYBIND11_MODULE(TVDCondat2013, m)
         :param float lambda: Regularisation parameter controlling smoothing.
         :returns: Denoised signal with the same dtype as ``signal``.
         :rtype: numpy.ndarray
+
+        Copyright (c) 2013-2025 Laurent Condat.
     )pbdoc";
 
     m.def("tvd_2013", &tvd::tvd_2013<double>, py::arg("signal").noconvert(),
@@ -577,5 +646,30 @@ PYBIND11_MODULE(TVDCondat2013, m)
           py::arg("lambda"), tvd_doc);
     m.def("tvd_2017", &tvd::tvd_2017<float>, py::arg("signal").noconvert(),
           py::arg("lambda"), tvd_doc);
+
+    m.def("tvd_tautstring", &tvd::tvd_tautstring<double>,
+          py::arg("signal").noconvert(), py::arg("lambda"), tvd_doc);
+    m.def("tvd_tautstring", &tvd::tvd_tautstring<float>,
+          py::arg("signal").noconvert(), py::arg("lambda"), tvd_doc);
+
+    const char *fl_doc = R"pbdoc(
+        Fused lasso signal approximation.
+
+        :param numpy.ndarray signal: 1-D array of ``float32`` or ``float64``
+            values.
+        :param float lambda: Total variation regularisation parameter.
+        :param float mu: L1 penalty on the signal values.
+        :returns: Denoised signal with the same dtype as ``signal``.
+        :rtype: numpy.ndarray
+
+        Copyright (c) 2013-2025 Laurent Condat.
+    )pbdoc";
+
+    m.def("fused_lasso", &tvd::fused_lasso_py<double>,
+          py::arg("signal").noconvert(), py::arg("lambda"), py::arg("mu"),
+          fl_doc);
+    m.def("fused_lasso", &tvd::fused_lasso_py<float>,
+          py::arg("signal").noconvert(), py::arg("lambda"), py::arg("mu"),
+          fl_doc);
 }
 

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -12,16 +12,31 @@ import TVDCondat2013 as tvd
 def test_tvd_preserves_dtype_and_values():
     """Lambda zero should yield an identical array with the same dtype."""
     x32 = np.array([0, 1, 2, 3], dtype=np.float32)
-    for func in (tvd.tvd_2013, tvd.tvd_2017):
+    for func in (tvd.tvd_2013, tvd.tvd_2017, tvd.tvd_tautstring):
         y32 = func(x32, np.float32(0.0))
         assert y32.dtype == np.float32
         np.testing.assert_array_equal(y32, x32)
 
     x64 = np.array([0.0, 1.0, 2.0, 3.0], dtype=np.float64)
-    for func in (tvd.tvd_2013, tvd.tvd_2017):
+    for func in (tvd.tvd_2013, tvd.tvd_2017, tvd.tvd_tautstring):
         y64 = func(x64, 0.0)
         assert y64.dtype == np.float64
         np.testing.assert_array_equal(y64, x64)
+
+
+def test_fused_lasso_identity():
+    """Lambda and mu zero should return the original signal."""
+    x32 = np.array([0, 1, 2, 3], dtype=np.float32)
+    y32 = tvd.fused_lasso(x32, np.float32(0.0), np.float32(0.0))
+    assert y32.dtype == np.float32
+    np.testing.assert_array_equal(y32, x32)
+
+    x64 = np.array([0.0, 1.0, 2.0, 3.0], dtype=np.float64)
+    y64 = tvd.fused_lasso(x64, 0.0, 0.0)
+    assert y64.dtype == np.float64
+    np.testing.assert_array_equal(y64, x64)
+
+
 def _total_variation(arr: np.ndarray) -> float:
     """Compute the total variation of a 1-D array."""
     return np.sum(np.abs(np.diff(arr)))
@@ -30,12 +45,12 @@ def _total_variation(arr: np.ndarray) -> float:
 def test_tvd_reduces_variation():
     """Denoising should not increase total variation."""
     x32 = np.array([0, 2, 1, 3, 0], dtype=np.float32)
-    for func in (tvd.tvd_2013, tvd.tvd_2017):
+    for func in (tvd.tvd_2013, tvd.tvd_2017, tvd.tvd_tautstring):
         y32 = func(x32, np.float32(0.5))
         assert _total_variation(y32) <= _total_variation(x32) + 1e-6
 
     x64 = np.array([0, 2, 1, 3, 0], dtype=np.float64)
-    for func in (tvd.tvd_2013, tvd.tvd_2017):
+    for func in (tvd.tvd_2013, tvd.tvd_2017, tvd.tvd_tautstring):
         y64 = func(x64, 0.5)
         assert _total_variation(y64) <= _total_variation(x64) + 1e-12
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -12,3 +12,4 @@ def test_extension_imports():
     module = importlib.import_module('TVDCondat2013')
     assert hasattr(module, 'tvd_2013')
     assert hasattr(module, 'tvd_2017')
+    assert hasattr(module, 'tvd_tautstring')


### PR DESCRIPTION
## Summary
- Introduce taut string total-variation denoiser and expose it as `tvd_tautstring`
- Annotate module, README, and docs with copyright notice and mention the new algorithm
- Extend smoke tests to cover the taut string variant
- Rework 2017 denoiser to follow Condat's 2017 reference implementation using a double-precision core
- Expand README and documentation to mention the fused lasso routine and update the example to exercise all denoisers

## Testing
- `python -m pip install -e .`
- `python examples/example_readme.py`
- `pytest -q`

