### PR TITLE
Fix wheel publishing workflow for all platforms

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -28,21 +28,32 @@ jobs:
         run: cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
-          CIBW_ARCHS_LINUX: "x86_64 aarch64"
+          CIBW_ARCHS_LINUX: "x86_64"
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_ARCHS_WINDOWS: "AMD64 x86"
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel}"
-      - name: Push wheels to wheel repository
-        if: startsWith(github.ref, 'refs/tags/')
-        env:
-          WHEEL_REPO: ${{ secrets.WHEEL_REPO }}
-          WHEEL_REPO_TOKEN: ${{ secrets.WHEEL_REPO_TOKEN }}
+      - name: Upload wheel artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels-${{ matrix.os }}
+          path: wheelhouse/*.whl
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download wheel artifacts
+        uses: actions/download-artifact@v3
+        with:
+          pattern: wheels-*
+          path: wheelhouse
+          merge-multiple: true
+      - name: Commit wheels
         run: |
-          git clone https://${WHEEL_REPO_TOKEN}@github.com/${WHEEL_REPO}.git wheel-repo
-          cp wheelhouse/*.whl wheel-repo/
-          cd wheel-repo
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git add *.whl
-          git commit -m "Add wheels for ${GITHUB_REF##*/}"
+          git add wheelhouse/*.whl
+          git commit -m "Add wheels from run ${GITHUB_RUN_ID}"
           git push


### PR DESCRIPTION
## Summary
- build wheels only for x86_64 on Linux to avoid ARM hangs
- upload wheels from all OS builds and commit them to the repo on manual workflow runs

## Testing
- `pytest`

