### PR TITLE
ci: use artifact actions v4

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -33,7 +33,7 @@ jobs:
           CIBW_ARCHS_WINDOWS: "AMD64 x86"
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel}"
       - name: Upload wheel artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.os }}
           path: wheelhouse/*.whl
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download wheel artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           pattern: wheels-*
           path: wheelhouse


### PR DESCRIPTION
## Summary
- switch upload/download artifact actions to v4 to resolve GitHub deprecation warnings

## Testing
- `python -m pip install .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b704c199e08328aee2c7cf62352b25