### PR TITLE
ci: manual release workflow with version bump

### DIFF
--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -1,0 +1,36 @@
+import re
+import sys
+from pathlib import Path
+
+increment = sys.argv[1]
+if increment not in {"0.1", "0.01"}:
+    raise SystemExit("increment must be 0.1 or 0.01")
+
+setup_path = Path("setup.py")
+conf_path = Path("docs/conf.py")
+
+def read_version(text):
+    m = re.search(r"__version__\s*=\s*['\"](\d+)\.(\d+)\.(\d+)['\"]", text)
+    if not m:
+        raise RuntimeError("version string not found")
+    return [int(part) for part in m.groups()]
+
+version_parts = read_version(setup_path.read_text())
+if increment == "0.1":
+    version_parts[1] += 1
+    version_parts[2] = 0
+else:
+    version_parts[2] += 1
+new_version = ".".join(str(p) for p in version_parts)
+
+setup_text = re.sub(r"(__version__\s*=\s*['\"])([^'\"]+)(['\"])",
+                    rf"\1{new_version}\3",
+                    setup_path.read_text())
+setup_path.write_text(setup_text)
+
+conf_text = conf_path.read_text()
+conf_text = re.sub(r"(version = u')([^']+)('\n)", rf"\1{new_version}\3", conf_text)
+conf_text = re.sub(r"(release = u')([^']+)('\n)", rf"\1{new_version}\3", conf_text)
+conf_path.write_text(conf_text)
+
+print(new_version)

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,14 +1,43 @@
 name: Build wheels
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version increment (0.1=minor, 0.01=patch)'
+        required: true
+        default: '0.01'
+        type: choice
+        options:
+          - '0.1'
+          - '0.01'
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
+      sha: ${{ steps.commit.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Bump version
+        id: bump
+        run: |
+          new_version=$(python .github/scripts/bump_version.py ${{ inputs.bump }})
+          echo "version=$new_version" >> "$GITHUB_OUTPUT"
+      - name: Commit version
+        id: commit
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git commit -am "Bump version to ${{ steps.bump.outputs.version }}"
+          git tag "v${{ steps.bump.outputs.version }}"
+          git push origin HEAD --tags
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build wheels on ${{ matrix.os }}
+    needs: prepare
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -16,6 +45,8 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-13, macos-14]
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -40,20 +71,16 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'workflow_dispatch'
+    needs: [build, prepare]
     steps:
-      - uses: actions/checkout@v3
-      - name: Download wheel artifacts
-        uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v4
         with:
           pattern: wheels-*
           path: wheelhouse
           merge-multiple: true
-      - name: Commit wheels
-        run: |
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git add wheelhouse/*.whl
-          git commit -m "Add wheels from run ${GITHUB_RUN_ID}"
-          git push
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ needs.prepare.outputs.version }}
+          name: v${{ needs.prepare.outputs.version }}
+          files: wheelhouse/*.whl

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ tmp/
 
 # OS X
 .DS_Store
+
+wheelhouse/


### PR DESCRIPTION
## Summary
- add bump_version script to increment package version
- overhaul wheel build workflow to run manually with version bump input and publish wheels as release assets
- ignore wheelhouse directory

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'TVDCondat2013')*

------
https://chatgpt.com/codex/tasks/task_e_68b94f2e4ac083289ab85a786c84c741